### PR TITLE
feat(auth/dashboard): add password toggles and relocate droid icons

### DIFF
--- a/src/app/ui/components/contact/ContactForm.tsx
+++ b/src/app/ui/components/contact/ContactForm.tsx
@@ -6,6 +6,7 @@ import { Listbox, Transition } from "@headlessui/react";
 import { ChevronsUpDown, Check } from "lucide-react";
 import { Fragment } from "react";
 import { enhancedNotifications } from "../../notificationService/notifications.service";
+import SocialNotification from "../socialLink/SocialNotification";
 
 interface ContactFormProps {
   serviceId: string;
@@ -284,9 +285,11 @@ const ContactForm: React.FC<ContactFormProps> = ({
       <p style={{ fontSize: "14px", color: "#555" }}>
         Kindly fill the form below to send us your message.
       </p>
+      <div style={{ marginLeft: "10px" }}>
+        <SocialNotification />
+      </div>
 
-      
-{/* 
+      {/* 
       {submitStatus === "success" && (
         <div
           style={{

--- a/src/app/ui/components/orgabizationLogin/OrganizationLogin.tsx
+++ b/src/app/ui/components/orgabizationLogin/OrganizationLogin.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { FaArrowLeft, FaBuilding } from "react-icons/fa"; 
+import { FaArrowLeft, FaBuilding, FaEye, FaEyeSlash } from "react-icons/fa"; // Added icons
 import { useNavigate } from "react-router-dom";
 import { authService } from "../../../redux/configuration/auth.service";
 import { RoutePaths } from "../../../routes/Index";
@@ -17,6 +17,9 @@ const OrganizationLogin: React.FC<any> = () => {
     password?: string;
   }>({});
   const [text, setText] = useState<string>("Login");
+
+  // State for password visibility
+  const [showPassword, setShowPassword] = useState(false);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -52,10 +55,10 @@ const OrganizationLogin: React.FC<any> = () => {
       await authService.handleUserLogin(
         formData.email,
         formData.password,
-        "Organisation" 
+        "Organisation"
       );
       setText("Loading Dashboard...");
-      
+
       // Redirects to normal dashboard for now
       navigate(RoutePaths.DashBoard, { replace: true });
     } catch (err) {
@@ -96,15 +99,29 @@ const OrganizationLogin: React.FC<any> = () => {
             )}
           </div>
 
-          <div className={styles.inputGroup}>
+          {/* Password Field with Eye Icon */}
+          <div className={styles.inputGroup} style={{ position: "relative" }}>
             <input
-              type="password"
+              type={showPassword ? "text" : "password"}
               name="password"
               placeholder="Password"
               value={formData.password}
               onChange={handleChange}
               className={styles.inputField}
+              style={{ paddingRight: "40px" }} // Make room for the icon
             />
+            <span
+              onClick={() => setShowPassword(!showPassword)}
+              style={{
+                position: "absolute",
+                right: "12px",
+                top: "14px",
+                cursor: "pointer",
+                color: "#BAB8B8",
+              }}
+            >
+              {showPassword ? <FaEyeSlash /> : <FaEye />}
+            </span>
             {formErrors.password && (
               <div className={styles.errorText}>{formErrors.password}</div>
             )}

--- a/src/app/ui/pages/Dashboard/member/MemberDashboard.tsx
+++ b/src/app/ui/pages/Dashboard/member/MemberDashboard.tsx
@@ -131,10 +131,10 @@ const MemberDashboard: React.FC<MemberDashboardProps> = ({
   const memberStats = useSelector((state: RootState) => state.memberStatus);
   const user = useSelector((state: RootState) => state.user);
   const userId = user?.uniqueId || user?.email || "guest";
-  
+
   // Check if user has already spun
-  const userSpin = useSelector((state: RootState) => 
-    state.spinner?.userSpins?.[userId] ?? null
+  const userSpin = useSelector(
+    (state: RootState) => state.spinner?.userSpins?.[userId] ?? null
   );
 
   type Notification = {
@@ -316,7 +316,9 @@ const MemberDashboard: React.FC<MemberDashboardProps> = ({
   }, [userSpin]);
 
   const handleSpinComplete = (outcome: number, giftAwarded: boolean) => {
-    console.log(`Spin completed! Outcome: ${outcome}, Gift awarded: ${giftAwarded}`);
+    console.log(
+      `Spin completed! Outcome: ${outcome}, Gift awarded: ${giftAwarded}`
+    );
     // The Redux state is already updated by the spinnerSlice
   };
 
@@ -432,10 +434,10 @@ const MemberDashboard: React.FC<MemberDashboardProps> = ({
               <div className="shp-welcome-content">
                 <div className="shp-greeting">
                   <h1 className="shp-welcome-title">Member Portal</h1>
-                  <div className="shp-head-icons-container">
-                    {/* Social Notification */}
+                  {/* <div className="shp-head-icons-container">
+                    {/* Social Notification 
                     <SocialNotification />
-                  </div>
+                  </div> */}
                 </div>
               </div>
             </div>
@@ -447,7 +449,7 @@ const MemberDashboard: React.FC<MemberDashboardProps> = ({
           </div>
         </div>
       </div>
-      
+
       {/* Member Stats */}
       <div className="shp-section">
         <h2 className="shp-section-title">Membership Overview</h2>

--- a/src/app/ui/pages/Dashboard/staff/StaffUserHomePage.tsx
+++ b/src/app/ui/pages/Dashboard/staff/StaffUserHomePage.tsx
@@ -584,7 +584,7 @@ const StaffUserHomePage: React.FC<StaffUserHomePageProps> = ({
                 )}
               </div> */}
               </div>
-              <SocialNotification />
+              {/* <SocialNotification /> */}
             </div>
             {/* <SocialNotification /> */}
           </div>

--- a/src/app/ui/pages/memberLogin/MemberLogin.tsx
+++ b/src/app/ui/pages/memberLogin/MemberLogin.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { FaUser, FaArrowLeft } from "react-icons/fa";
+import { FaUser, FaArrowLeft, FaEye, FaEyeSlash } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
 import { authService } from "../../../redux/configuration/auth.service";
 import { RoutePaths } from "../../../routes/Index";
@@ -13,6 +13,9 @@ const MemberLogin = () => {
     password?: string;
   }>({});
   const [text, setText] = useState<string>("Login");
+
+  // State for password visibility
+  const [showPassword, setShowPassword] = useState(false);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -89,15 +92,29 @@ const MemberLogin = () => {
             )}
           </div>
 
-          <div className={styles.inputGroup}>
+          {/* Password Field with Eye Icon */}
+          <div className={styles.inputGroup} style={{ position: "relative" }}>
             <input
-              type="password"
+              type={showPassword ? "text" : "password"}
               name="password"
               placeholder="Password"
               value={formData.password}
               onChange={handleChange}
               className={styles.input}
+              style={{ paddingRight: "40px" }} // Added padding for icon space
             />
+            <span
+              onClick={() => setShowPassword(!showPassword)}
+              style={{
+                position: "absolute",
+                right: "12px",
+                top: "14px",
+                cursor: "pointer",
+                color: "#BAB8B8",
+              }}
+            >
+              {showPassword ? <FaEyeSlash /> : <FaEye />}
+            </span>
             {formErrors.password && (
               <div className={styles.error}>{formErrors.password}</div>
             )}

--- a/src/app/ui/pages/staffLogin/StaffLogin.tsx
+++ b/src/app/ui/pages/staffLogin/StaffLogin.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { FaArrowLeft, FaUsers } from "react-icons/fa";
+import { FaArrowLeft, FaUsers, FaEye, FaEyeSlash } from "react-icons/fa"; // Added icons
 import { useNavigate } from "react-router-dom";
 import { authService } from "../../../redux/configuration/auth.service";
 import { RoutePaths } from "../../../routes/Index";
@@ -17,6 +17,9 @@ const StaffLogin: React.FC<any> = () => {
     password?: string;
   }>({});
   const [text, setText] = useState<string>("Login");
+
+  // State for password visibility
+  const [showPassword, setShowPassword] = useState(false);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -94,15 +97,29 @@ const StaffLogin: React.FC<any> = () => {
             )}
           </div>
 
-          <div className={styles.inputGroup}>
+          {/* Password Field with Eye Icon */}
+          <div className={styles.inputGroup} style={{ position: "relative" }}>
             <input
-              type="password"
+              type={showPassword ? "text" : "password"}
               name="password"
               placeholder="Password"
               value={formData.password}
               onChange={handleChange}
               className={styles.inputField}
+              style={{ paddingRight: "40px" }} // Make room for the icon
             />
+            <span
+              onClick={() => setShowPassword(!showPassword)}
+              style={{
+                position: "absolute",
+                right: "12px",
+                top: "14px",
+                cursor: "pointer",
+                color: "#BAB8B8",
+              }}
+            >
+              {showPassword ? <FaEyeSlash /> : <FaEye />}
+            </span>
             {formErrors.password && (
               <div className={styles.errorText}>{formErrors.password}</div>
             )}


### PR DESCRIPTION
- Add password visibility toggle (eye/eye-slash) to Staff, Member, and Organization login pages to improve user experience.
- Remove D'roid icons from the Dashboard Home view.
- Relocate D'roid icons to the "Say It" page for all user accounts, as explicitly directed by the GM.